### PR TITLE
TRON-4770: Fix filename extraction on Windows

### DIFF
--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -569,7 +569,7 @@ function getPDFFileNameFromURL(url, defaultFilename = 'document.pdf') {
   const reURI = /^(?:(?:[^:]+:)?\/\/[^\/]+)?([^?#]*)(\?[^#]*)?(#.*)?$/;
   //            SCHEME        HOST         1.PATH  2.QUERY   3.REF
   // Pattern to get last matching NAME.pdf
-  const reFilename = /[^\/?#=]+\.pdf\b(?!.*\.pdf\b)/i;
+  const reFilename = /[^(\/|\\)?#=]+\.pdf\b(?!.*\.pdf\b)/i;
   let splitURI = reURI.exec(url);
   let suggestedFilename = reFilename.exec(splitURI[1]) ||
                           reFilename.exec(splitURI[2]) ||


### PR DESCRIPTION
https://redbrickmedia.atlassian.net/browse/TRON-4770

PDFJS parsing completely disregards that back slashes could be a part of the file path, which results in it not working at all for Windows file paths.

Backslashes are escape characters on *nix systems so this should have no effect on parsing in Mac or Linux and hasn't so far in my testing.

The question is which branch we want to merge this to, and how to rebuild the output folder to have this change.

